### PR TITLE
introduce nodes

### DIFF
--- a/config.go
+++ b/config.go
@@ -138,6 +138,24 @@ func (n Node) isLeaf() bool {
 	return len(n.children) == 0
 }
 
+func (n *Node) Add(v interface{}, path_ ...interface{}) *Node {
+	path := NodePath(path_)
+
+	if len(path) == 0 {
+		n.value = v
+		return n
+	}
+
+	child, err := n.find(path[0])
+	if err == nil {
+		child.Add(v, path[1:]...)
+	} else {
+		new := &Node{value: path[0], children: []*Node{}}
+		n.children = append(n.children, new.Add(v, path[1:]...))
+	}
+	return n
+}
+
 func (n Node) find(path_ ...interface{}) (Node, error) {
 	path := NodePath(path_)
 

--- a/config.go
+++ b/config.go
@@ -41,7 +41,7 @@ func (root Node) toMap() map[string]interface{} {
 				asArray, isArray := runningVal.([]interface{})
 
 				cString, cStringp := runningNode.value.(string)
-				// cInt, cIntp  := runningNode.value.(int)
+				cInt, cIntp  := runningNode.value.(int)
 
 				// nString, nStringp := next.value.(string)
 				_, nStringp := next.value.(string)
@@ -51,15 +51,17 @@ func (root Node) toMap() map[string]interface{} {
 				if next.isLeaf() {
 					vlog("next is leaf")
 					if isMap && cStringp {
-						vlog("is leaf: %s %s", cString, next.value)
+						vlog("is leaf map: %s %s", cString, next.value)
 						asMap[cString] = next.value
 						// runningVal.(map[string]interface{})[cString] = next.value
 						break
 					}
-					if isArray {
-						asArray = append(asArray, next.value)
+					if isArray && cIntp {
+						vlog("is leaf array: %v %v", cInt, next.value)
+						asArray[0] = next.value
 						break
 					}
+					panic("what")
 				}
 
 				var nextVal interface{}
@@ -67,22 +69,23 @@ func (root Node) toMap() map[string]interface{} {
 				if nStringp {
 					nextVal = map[string]interface{}{}
 				} else if nIntp {
-					nextVal = []interface{}{}
+					// throwing this value away
+					nextVal = []interface{}{nil}
 				}
 
 				if isMap {
 					asMap[cString] = nextVal
 					runningVal = asMap[cString]
 				} else if isArray {
-					asArray = append(asArray, nextVal)
-					runningVal = asArray[0]
+					asArray[0] = nextVal
 				}
 
 				runningNode = next
 			}
 
 			vlog("resulting map: %v", base)
-			if err := mergo.Merge(&result, base); err != nil {
+
+			if err := mergo.Merge(&result, base, mergo.WithAppendSlice); err != nil {
 				panic(err)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 )

--- a/gott_test.go
+++ b/gott_test.go
@@ -49,7 +49,7 @@ func TestNode(t *testing.T) {
 	findEqual("b", n, "a", "b")
 
 	n.changeLeaves([]interface{}{},
-		func(n *Node, _ []interface{}) (interface{}, error) {
+		func(n *Node, _ NodePath) (interface{}, error) {
 			return n.value.(string) + "foo", nil
 		})
 
@@ -81,7 +81,7 @@ func TestNode(t *testing.T) {
 		},
 	}
 
-	equal(mapExpected, n.toMap())
+	equal(mapExpected, n.ToMap())
 
 	n = Node {"root",
 		[]*Node{
@@ -106,6 +106,6 @@ func TestNode(t *testing.T) {
 		},
 	}
 
-	equal(mapExpected, n.toMap())
+	equal(mapExpected, n.ToMap())
 
 }

--- a/gott_test.go
+++ b/gott_test.go
@@ -46,19 +46,6 @@ func TestNode(t *testing.T) {
 		},
 	}
 
-	nSinglePathMap := Node {"root",
-		[]*Node{
-			&Node{"a",
-				[]*Node{
-					&Node{"b", []*Node{}},
-					// &Node{"c", []*Node{}},
-				},
-			},
-		},
-	}
-
-
-
 	findEqual("b", n, "a", "b")
 
 	n.changeLeaves([]interface{}{},
@@ -68,11 +55,57 @@ func TestNode(t *testing.T) {
 
 	findEqual("bfoo", n, "a", "bfoo")
 
-	mapExpected := map[string]interface{}{"root":
-		map[string]interface{}{"a":
-			"b",
+
+	n = Node {"root",
+		[]*Node{
+			&Node{"a",
+				[]*Node{
+					&Node{"a", []*Node{}},
+				},
+			},
+			&Node{"b",
+				[]*Node{
+					&Node{"b", []*Node{}},
+				},
+			},
 		},
 	}
 
-	equal(mapExpected, nSinglePathMap.toMap())
+	// toml top level
+	// a = "a"
+	// b = "b"
+	mapExpected := map[string]interface{}{
+		"root": map[string]interface{}{
+			"a": "a",
+			"b": "b",
+		},
+	}
+
+	equal(mapExpected, n.toMap())
+
+	n = Node {"root",
+		[]*Node{
+			&Node{"a",
+				[]*Node{
+					&Node{0, []*Node{&Node{"zero", []*Node{}},}},
+					&Node{1, []*Node{&Node{2, []*Node{}},}},
+				},
+			},
+			&Node{"b",
+				[]*Node{
+					&Node{"b", []*Node{}},
+				},
+			},
+		},
+	}
+
+	mapExpected = map[string]interface{}{
+		"root": map[string]interface{}{
+			"a": []interface{}{"zero", 2},
+			"b": "b",
+		},
+	}
+
+	equal(mapExpected, n.toMap())
+
 }

--- a/gott_test.go
+++ b/gott_test.go
@@ -108,4 +108,16 @@ func TestNode(t *testing.T) {
 
 	equal(mapExpected, n.ToMap())
 
+	n = Node{"root", []*Node{}}
+	n.Add("a", 1)
+	n.Add("b", 2)
+
+	mapExpected = map[string]interface{}{
+		"root": map[string]interface{}{
+			"a": 1,
+			"b": 2,
+		},
+	}
+
+	equal(mapExpected, n.ToMap())
 }

--- a/gott_test.go
+++ b/gott_test.go
@@ -1,9 +1,6 @@
 package main
 
-// type x map[string]x
-
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,14 +47,8 @@ func TestFromMap(t *testing.T) {
 	s, _ := n.view("mapString")
 	vlog("arst: %s", s)
 
-	var mu sync.Mutex
-	mapToNode(&n, data, NodePath{},
-		func(path NodePath) {
-			mu.Lock()
-			defer mu.Unlock()
-			n.add(path)
-		},
-	)
+	// var mu sync.Mutex
+	mapToNode(&n, data, NodePath{})
 
 	s, _ = n.view("mapString")
 	vlog("arst2: %s", s)
@@ -93,7 +84,6 @@ func TestAdd(t *testing.T) {
 	n.add("a", 1)
 	n.add("b", 2)
 	n.add("array", 0, "a")
-	vlog("fuckass")
 	n.add("array", 1, "b")
 
 	n.mustFind("array", 1, "b")

--- a/gott_test.go
+++ b/gott_test.go
@@ -1,0 +1,78 @@
+package main
+
+import "testing"
+import "reflect"
+
+func TestNode(t *testing.T) {
+	verbose = true
+
+	equal := func(expected, result interface{}) {
+		if !reflect.DeepEqual(expected, result) {
+			t.Fatalf("Expected vs Result:\n%v\n%v", expected, result)
+		}
+	}
+
+	findEqual:= func(expected interface{}, n Node, path ...interface{}) {
+		r, err := n.find(path...)
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+		equal(expected, r.value)
+	}
+
+	n := Node {"root",
+		[]*Node{
+			&Node{"a",
+				[]*Node{
+					&Node{"b", []*Node{}},
+					&Node{"c", []*Node{}},
+				},
+			},
+			&Node{"array",
+				[]*Node{
+					&Node{0,
+						[]*Node{
+							&Node{"b", []*Node{}},
+						},
+					},
+					&Node{1,
+						[]*Node{
+							&Node{"c", []*Node{}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	nSinglePathMap := Node {"root",
+		[]*Node{
+			&Node{"a",
+				[]*Node{
+					&Node{"b", []*Node{}},
+					// &Node{"c", []*Node{}},
+				},
+			},
+		},
+	}
+
+
+
+	findEqual("b", n, "a", "b")
+
+	n.changeLeaves([]interface{}{},
+		func(n *Node, _ []interface{}) (interface{}, error) {
+			return n.value.(string) + "foo", nil
+		})
+
+	findEqual("bfoo", n, "a", "bfoo")
+
+	mapExpected := map[string]interface{}{"root":
+		map[string]interface{}{"a":
+			"b",
+		},
+	}
+
+	equal(mapExpected, nSinglePathMap.toMap())
+}

--- a/gott_test.go
+++ b/gott_test.go
@@ -1,37 +1,22 @@
 package main
 
+// type x map[string]x
+
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNode(t *testing.T) {
-	verbose = true
-
-	n := Node{"root",
-		[]*Node{
-			&Node{"a",
-				[]*Node{
-					&Node{"b", []*Node{}},
-				},
-			},
-			&Node{"array",
-				[]*Node{
-					&Node{0,
-						[]*Node{
-							&Node{"b", []*Node{}},
-						},
-					},
-					&Node{1,
-						[]*Node{
-							&Node{"c", []*Node{}},
-						},
-					},
-				},
-			},
-		},
-	}
+	n := NewNode("root",
+		NewNode("a", NewNode("b")),
+		NewNode("array",
+			NewNode(0, NewNode("b")),
+			NewNode(1, NewNode("c")),
+		),
+	)
 
 	assert.Equal(t, "b", n.mustFind("a", "b").value)
 
@@ -52,22 +37,45 @@ func TestNode(t *testing.T) {
 	assert.Equal(t, "bfoo", n.mustFind("a", "bfoo").value)
 }
 
-func TestToMap(t *testing.T) {
-	n := Node{"root",
-		[]*Node{
-			&Node{"a",
-				[]*Node{
-					&Node{0, []*Node{&Node{"zero", []*Node{}}}},
-					&Node{1, []*Node{&Node{2, []*Node{}}}},
-				},
-			},
-			&Node{"b",
-				[]*Node{
-					&Node{"b", []*Node{}},
-				},
-			},
-		},
+func TestFromMap(t *testing.T) {
+
+	verbose = true
+	data := map[string]interface{}{
+		// "a":     "b",
+		"array": []interface{}{"b", "c"},
 	}
+
+	n := Node{value: "r", children: []*Node{}}
+
+	s, _ := n.view("mapString")
+	vlog("arst: %s", s)
+
+	var mu sync.Mutex
+	mapToNode(&n, data, NodePath{},
+		func(path NodePath) {
+			mu.Lock()
+			defer mu.Unlock()
+			n.add(path)
+		},
+	)
+
+	s, _ = n.view("mapString")
+	vlog("arst2: %s", s)
+
+	// n.mustFind("a", "b")
+	// n.mustFind("array", 0)
+	vlog("arst: %v", n.mustFind("array"))
+	n.mustFind("array", 1)
+}
+
+func TestToMap(t *testing.T) {
+	n := NewNode("root",
+		NewNode("a",
+			NewNode(0, NewNode("zero")),
+			NewNode(1, NewNode(2)),
+		),
+		NewNode("b", NewNode("b")),
+	)
 
 	mapExpected := map[string]interface{}{
 		"root": map[string]interface{}{
@@ -80,14 +88,21 @@ func TestToMap(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	n := Node{"root", []*Node{}}
+	verbose = true
+	n := NewNode("root")
 	n.add("a", 1)
 	n.add("b", 2)
+	n.add("array", 0, "a")
+	vlog("fuckass")
+	n.add("array", 1, "b")
+
+	n.mustFind("array", 1, "b")
 
 	mapExpected := map[string]interface{}{
 		"root": map[string]interface{}{
-			"a": 1,
-			"b": 2,
+			"a":     1,
+			"b":     2,
+			"array": []interface{}{"a", "b"},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -49,12 +49,12 @@ func main() {
 		})
 
 	vlog(rootNode.view("toml"))
-
 	vlog("------")
 
-	// not doing this for now.
-	// rootNode.Transform(c, []string{}, identTransform)
-	// vlog(rootNode.View("toml"))
+	rootNode.changeLeaves(NodePath{},
+		func(n *Node, path NodePath) (interface{}, error) {
+			return identTransform(n, path, *rootNode)
+		})
 
 	realizeTransform := func(n *Node, path NodePath) (interface{}, error) {
 		if fmt.Sprintf("%T", n.value) != "string" {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
+	// "strings"
 )
 
 var verbose bool = false
@@ -39,78 +39,80 @@ func main() {
 	flag.Parse()
 
 	c := parseToml(tomlFiles, tomlText)
-	tmpl := makeTemplate()
 
-	c.Transform(c, []string{}, qualifyTransform)
-	vlog(c.View("toml"))
+	os.Exit(0)
+	// tmpl := makeTemplate()
+	// c.Transform(c, []string{}, qualifyTransform)
 
-	vlog("------")
-	c.Transform(c, []string{}, identTransform)
-	vlog(c.View("toml"))
+	// // vlog(c.View("toml"))
 
-	realizeTransform := func(v string, c config, path []string) (string, error) {
-		// oof
-		for strings.Contains(v, "{{") {
-			original := v
-			name := strings.Join(path, ".")
-			vlog("rendering %s: %s", name, v)
-			v = c.Render(tmpl, v)
-			if original != v {
-				vlog("   result %s: %s", name, v)
-			}
-		}
-		return v, nil
-	}
+	// vlog("------")
+	// c.Transform(c, []string{}, identTransform)
+	// vlog(c.View("toml"))
 
-	c.Transform(c, []string{}, realizeTransform)
+	// realizeTransform := func(v string, c config, path []string) (string, error) {
+	// 	// oof
+	// 	for strings.Contains(v, "{{") {
+	// 		original := v
+	// 		name := strings.Join(path, ".")
+	// 		vlog("rendering %s: %s", name, v)
+	// 		v = c.Render(tmpl, v)
+	// 		if original != v {
+	// 			vlog("   result %s: %s", name, v)
+	// 		}
+	// 	}
+	// 	return v, nil
+	// }
 
-	for _, p := range promotions {
-		c = c.Promote(strings.Split(p, "."))
-	}
+	// c.Transform(c, []string{}, realizeTransform)
 
-	if narrow != "" {
-		d, is_map, err := c.Dig(strings.Split(narrow, "."))
-		if err != nil {
-			panic(err)
-		}
-		if !is_map {
-			glog.Fatalf("Narrowed to a non-map value! %s. Use -q instead.", narrow)
-		}
-		c = d
-	}
+	// for _, p := range promotions {
+	// 	c = c.Promote(strings.Split(p, "."))
+	// }
 
-	if action != "" {
-		view, err := c.View(action)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Print(view)
-	}
+	// if narrow != "" {
+	// 	d, is_map, err := c.Dig(strings.Split(narrow, "."))
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	if !is_map {
+	// 		glog.Fatalf("Narrowed to a non-map value! %s. Use -q instead.", narrow)
+	// 	}
+	// 	c = d
+	// }
 
-	for _, file := range renderTargets {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			glog.Fatalf("render file not found: %s", file)
-		}
+	// if action != "" {
+	// 	view, err := c.View(action)
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	fmt.Print(view)
+	// }
 
-		r, err := identTransform(string(bytes), c, []string{})
-		fmt.Println(c.Render(tmpl, r))
-	}
+	// for _, file := range renderTargets {
+	// 	bytes, err := os.ReadFile(file)
+	// 	if err != nil {
+	// 		glog.Fatalf("render file not found: %s", file)
+	// 	}
 
-	if queryString != "" {
-		// text/template doesn't like '-', but you can get around it with the index function
-		// {{wow.a-thing.cool}} -> {{index .wow "a-thing" "cool"}}
-		parts := strings.Split(queryString, ".")
-		if len(parts) > 1 {
-			queryString = fmt.Sprintf("{{index .%s \"%s\"}}", parts[0], strings.Join(parts[1:], "\" \""))
-			vlog("queryString: %s", queryString)
-		} else {
-			queryString = "{{." + queryString + "}}"
-		}
-		fmt.Println(c.Render(tmpl, queryString))
-	}
+	// 	r, err := identTransform(string(bytes), c, []string{})
+	// 	fmt.Println(c.Render(tmpl, r))
+	// }
 
-	if queryStringPlain != "" {
-		fmt.Println(c.Render(tmpl, queryStringPlain))
-	}
+	// if queryString != "" {
+	// 	// text/template doesn't like '-', but you can get around it with the index function
+	// 	// {{wow.a-thing.cool}} -> {{index .wow "a-thing" "cool"}}
+	// 	parts := strings.Split(queryString, ".")
+	// 	if len(parts) > 1 {
+	// 		queryString = fmt.Sprintf("{{index .%s \"%s\"}}", parts[0], strings.Join(parts[1:], "\" \""))
+	// 		vlog("queryString: %s", queryString)
+	// 	} else {
+	// 		queryString = "{{." + queryString + "}}"
+	// 	}
+	// 	fmt.Println(c.Render(tmpl, queryString))
+	// }
+
+	// if queryStringPlain != "" {
+	// 	fmt.Println(c.Render(tmpl, queryStringPlain))
+	// }
 }

--- a/main.go
+++ b/main.go
@@ -104,11 +104,9 @@ func main() {
 	}
 
 	if queryString != "" {
-		// text/template doesn't like '-', but you can get around it with the index function
-		// {{wow.a-thing.cool}} -> {{index .wow "a-thing" "cool"}}
 		s := toPath(queryString).ToIndexCall()
 		queryString = "{{" + s + "}}"
-		fmt.Println(rootNode.render(tmpl, queryString))
+		fmt.Println(rootNode.mustRender(tmpl, queryString))
 	}
 
 	if queryStringPlain != "" {

--- a/main.go
+++ b/main.go
@@ -79,8 +79,8 @@ func main() {
 
 	rootNode.changeLeaves(NodePath{}, realizeTransform)
 
-	if len(promotions) > 0 {
-		rootNode.promote(toPath(strings.Join(promotions, ".")))
+	for _, p := range promotions {
+		rootNode.promote(toPath(p))
 	}
 
 	if narrow != "" {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,10 @@ func main() {
 
 	rootNode.changeLeaves(NodePath{},
 		func(n *Node, path NodePath) (interface{}, error) {
-			return identTransform(n, path, *rootNode)
+			if fmt.Sprintf("%T", n.value) != "string" {
+				return n.value, nil
+			}
+			return identTransform(n.value.(string))
 		})
 
 	realizeTransform := func(n *Node, path NodePath) (interface{}, error) {
@@ -98,9 +101,8 @@ func main() {
 			glog.Fatalf("render file not found: %s", file)
 		}
 
-		// r, err := identTransform(string(bytes), c, []string{})
-		// fmt.Println(c.Render(tmpl, r))
-		fmt.Println(rootNode.render(tmpl, string(bytes)))
+		r, err := identTransform(string(bytes))
+		fmt.Println(rootNode.mustRender(tmpl, r))
 	}
 
 	if queryString != "" {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
+	// "fmt"
 	"log"
 	"os"
 	// "strings"
@@ -38,7 +38,14 @@ func main() {
 	flag.StringVar(&narrow, "n", "", "Narrow the namespaces to consider")
 	flag.Parse()
 
-	c := parseToml(tomlFiles, tomlText)
+	// c := parseToml(tomlFiles, tomlText)
+
+	// test := Node{
+	// 	"a",
+	// 	[
+	// 		Node"c"
+	// 		]
+	// }
 
 	os.Exit(0)
 	// tmpl := makeTemplate()

--- a/node.go
+++ b/node.go
@@ -152,6 +152,25 @@ func (root *Node) toMap() map[string]interface{} {
 	return result
 }
 
+// doesn't include surrounding {{}}
+func (path NodePath) ToIndexCall() string {
+	if len(path) == 1 {
+		return "." + path[0].(string)
+	}
+
+	result := "index"
+	for _, v := range path {
+		switch v := v.(type) {
+		case string:
+			result = result + fmt.Sprintf(" \"%s\" ", v)
+		case int:
+			result = result + fmt.Sprintf(" %d ", v)
+		}
+	}
+
+	return result
+}
+
 func (path NodePath) ToString() string {
 	result := ""
 	for _, v := range path {
@@ -269,7 +288,18 @@ func (n Node) view(kind string) (string, error) {
 func (n Node) render(tmpl *template.Template, text string) (string, error) {
 	t := template.Must(tmpl.Parse(text))
 	result := new(bytes.Buffer)
-	err := t.Execute(result, n.toMap())
+
+	// ehhhhh
+	m := n.toMap()["root"].(map[string]interface{})
+
+	vlog("-----render map: ")
+	for k, v := range m {
+		vlog("%s: %v", k, v)
+	}
+	// vlog("render map: %v", m)
+
+	vlog("rendering (inner): %s", text)
+	err := t.Execute(result, m)
 	return result.String(), err
 }
 

--- a/node.go
+++ b/node.go
@@ -152,10 +152,6 @@ func (root *Node) toMap() map[string]interface{} {
 
 // doesn't include surrounding {{}}
 func (path NodePath) ToIndexCall() string {
-	if len(path) == 1 {
-		return "." + path[0].(string)
-	}
-
 	result := "index . "
 	for _, v := range path {
 		switch v := v.(type) {
@@ -242,7 +238,8 @@ func (n Node) toFlatMap() map[string]string {
 	results := map[string]string{}
 	n.changeLeaves(NodePath{},
 		func(n *Node, path NodePath) (interface{}, error) {
-			results[path.ToString()] = fmt.Sprintf("%v", n.value)
+			// remove "root", value node
+			results[path[1:len(path)-1].ToString()] = fmt.Sprintf("%v", n.value)
 			return n.value, nil
 		})
 	return results

--- a/node.go
+++ b/node.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
 	// "text/template"
 
 	"github.com/imdario/mergo"
 	"github.com/pelletier/go-toml/v2"
 )
-
 
 type NodePath []interface{} // collection of strings and ints leading to a node
 
@@ -22,158 +22,8 @@ type Node struct {
 	children []*Node
 }
 
-func (root Node) ToMap() map[string]interface{} {
-	result := map[string]interface{}{}
-
-	root.changeLeaves([]interface{}{},
-		func(n *Node, path NodePath) (interface{}, error) {
-			vlog("map from leaf: %s", path.ToString())
-			path = path[1:]
-
-			var base interface{} = map[string]interface{}{}
-			var runningVal interface{} = base
-
-			runningNode := root
-
-			for _, p := range path {
-				vlog("base: %v", base)
-
-				next, err := runningNode.find(p)
-				if err != nil {
-					panic(err)
-				}
-
-				asMap, isMap := runningVal.(map[string]interface{})
-				asArray, isArray := runningVal.([]interface{})
-
-				cString, cStringp := runningNode.value.(string)
-				cInt, cIntp  := runningNode.value.(int)
-
-				_, nStringp := next.value.(string)
-				_, nIntp  := next.value.(int)
-
-				if next.isLeaf() {
-					vlog("next is leaf")
-					if isMap && cStringp {
-						vlog("is leaf map: %s %s", cString, next.value)
-						asMap[cString] = next.value
-						// runningVal.(map[string]interface{})[cString] = next.value
-						break
-					}
-					if isArray && cIntp {
-						vlog("is leaf array: %v %v", cInt, next.value)
-						asArray[0] = next.value
-						break
-					}
-					panic("what")
-				}
-
-				var nextVal interface{}
-
-				if nStringp {
-					nextVal = map[string]interface{}{}
-				} else if nIntp {
-					// throwing this value away
-					nextVal = []interface{}{nil}
-				}
-
-				if isMap {
-					asMap[cString] = nextVal
-					runningVal = asMap[cString]
-				} else if isArray {
-					asArray[0] = nextVal
-				}
-
-				runningNode = next
-			}
-
-			vlog("resulting map: %v", base)
-
-			if err := mergo.Merge(&result, base, mergo.WithAppendSlice); err != nil {
-				panic(err)
-			}
-
-			return n.value, nil
-		})
-
-	return result
-}
-
-func (path NodePath) ToString() string {
-	result := ""
-	for _, v := range path {
-		switch v := v.(type) {
-
-		case string:
-			result = result + v + "."
-		case int:
-			result = result + fmt.Sprintf("%d", v) + "."
-		}
-	}
-
-	if result != "" {
-		// remove trailing .
-		result = result[0:len(result)-1]
-	}
-	return result
-}
-
-// "path" is a slice of strings+ints leading to a node in config
-// todo: see about using type alises to define these methods on strings/interface{}?
-func toPath(s string) NodePath {
-	path := []interface{}{}
-	for _, v := range strings.Split(s, ".") {
-		// todo: this should account for ints
-		i, err := strconv.Atoi(v)
-		if err == nil {
-			path = append(path, i)
-		} else {
-			path = append(path, v)
-		}
-	}
-	return path
-}
-
 func (n Node) isLeaf() bool {
 	return len(n.children) == 0
-}
-
-func (n *Node) Add(v interface{}, path_ ...interface{}) *Node {
-	path := NodePath(path_)
-
-	if len(path) == 0 {
-		n.value = v
-		return n
-	}
-
-	child, err := n.find(path[0])
-	if err == nil {
-		child.Add(v, path[1:]...)
-	} else {
-		new := &Node{value: path[0], children: []*Node{}}
-		n.children = append(n.children, new.Add(v, path[1:]...))
-	}
-	return n
-}
-
-func (n Node) find(path_ ...interface{}) (Node, error) {
-	path := NodePath(path_)
-
-	if len(path) == 0 {
-		return n, nil
-	}
-
-	vlog("find: %s", path.ToString())
-
-	for _, n_ := range n.children {
-		vlog("find: compare %v == %v ?", path[0], n_.value)
-		if n_.value == path[0] {
-			vlog("find: found %s!", path[0])
-			return n_.find(path[1:]...)
-		}
-	}
-
-	return Node{}, errors.New("Couldn't find path! " + path.ToString())
 }
 
 func (n *Node) changeLeaves(path NodePath, operation func(*Node, NodePath) (interface{}, error)) error {
@@ -199,7 +49,166 @@ func (n *Node) changeLeaves(path NodePath, operation func(*Node, NodePath) (inte
 	return nil
 }
 
-func (n Node) ToFlatMap() map[string]string {
+func (n *Node) add(path_ ...interface{}) {
+	path := NodePath(path_)
+
+	if len(path) == 0 {
+		return
+	}
+
+	child, err := n.find(path[0])
+
+	if err == nil {
+		child.add(path[1:]...)
+	} else {
+		new := &Node{value: path[0], children: []*Node{}}
+		new.add(path[1:]...)
+		n.children = append(n.children, new)
+	}
+}
+
+func (root Node) toMap() map[string]interface{} {
+	result := map[string]interface{}{}
+
+	root.changeLeaves([]interface{}{},
+		func(n *Node, path NodePath) (interface{}, error) {
+			// vlog("map from leaf: %s", path.ToString())
+			path = path[1:]
+
+			var base interface{} = map[string]interface{}{}
+			var runningVal interface{} = base
+
+			runningNode := root
+
+			for _, p := range path {
+				// vlog("base: %v", base)
+
+				next, err := runningNode.find(p)
+				if err != nil {
+					panic(err)
+				}
+
+				asMap, isMap := runningVal.(map[string]interface{})
+				asArray, isArray := runningVal.([]interface{})
+
+				cString, cStringp := runningNode.value.(string)
+				// cInt, cIntp  := runningNode.value.(int)
+				_, cIntp := runningNode.value.(int)
+
+				_, nStringp := next.value.(string)
+				_, nIntp := next.value.(int)
+
+				if next.isLeaf() {
+					// vlog("next is leaf")
+					if isMap && cStringp {
+						// vlog("is leaf map: %s %s", cString, next.value)
+						asMap[cString] = next.value
+						// runningVal.(map[string]interface{})[cString] = next.value
+						break
+					}
+					if isArray && cIntp {
+						// vlog("is leaf array: %v %v", cInt, next.value)
+						asArray[0] = next.value
+						break
+					}
+					panic("what")
+				}
+
+				var nextVal interface{}
+
+				if nStringp {
+					nextVal = map[string]interface{}{}
+				} else if nIntp {
+					// throwing this value away
+					nextVal = []interface{}{nil}
+				}
+
+				if isMap {
+					asMap[cString] = nextVal
+					runningVal = asMap[cString]
+				} else if isArray {
+					asArray[0] = nextVal
+				}
+
+				runningNode = next
+			}
+
+			// vlog("resulting map: %v", base)
+
+			if err := mergo.Merge(&result, base, mergo.WithAppendSlice); err != nil {
+				panic(err)
+			}
+
+			return n.value, nil
+		})
+
+	return result
+}
+
+func (path NodePath) ToString() string {
+	result := ""
+	for _, v := range path {
+		switch v := v.(type) {
+
+		case string:
+			result = result + v + "."
+		case int:
+			result = result + fmt.Sprintf("%d", v) + "."
+		}
+	}
+
+	if result != "" {
+		// remove trailing .
+		result = result[0 : len(result)-1]
+	}
+	return result
+}
+
+// "path" is a slice of strings+ints leading to a node in config
+// todo: see about using type alises to define these methods on strings/interface{}?
+func toPath(s string) NodePath {
+	path := []interface{}{}
+	for _, v := range strings.Split(s, ".") {
+		// todo: this should account for ints
+		i, err := strconv.Atoi(v)
+		if err == nil {
+			path = append(path, i)
+		} else {
+			path = append(path, v)
+		}
+	}
+	return path
+}
+
+func (n Node) find(path_ ...interface{}) (Node, error) {
+	path := NodePath(path_)
+
+	if len(path) == 0 {
+		return n, nil
+	}
+
+	vlog("find: %s", path.ToString())
+
+	for _, n_ := range n.children {
+		vlog("find: compare %v == %v ?", path[0], n_.value)
+		if n_.value == path[0] {
+			vlog("find: found %s!", path[0])
+			return n_.find(path[1:]...)
+		}
+	}
+
+	return Node{}, errors.New("Couldn't find path! " + path.ToString())
+}
+
+func (n Node) mustFind(path_ ...interface{}) Node {
+	r, err := n.find(path_...)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func (n Node) toFlatMap() map[string]string {
 	results := map[string]string{}
 	n.changeLeaves([]interface{}{},
 		func(n *Node, path NodePath) (interface{}, error) {
@@ -209,24 +218,24 @@ func (n Node) ToFlatMap() map[string]string {
 	return results
 }
 
-func (n Node) View(kind string) (string, error) {
+func (n Node) view(kind string) (string, error) {
 	switch kind {
 	case "toml":
-		b, err := toml.Marshal(n.ToMap())
+		b, err := toml.Marshal(n.toMap())
 		if err != nil {
 			panic(err)
 		}
 		return string(b), nil
 	case "keys":
 		keys := []string{}
-		for k, _ := range n.ToFlatMap() {
+		for k, _ := range n.toFlatMap() {
 			keys = append(keys, k)
 		}
 		return strings.Join(keys, "\n") + "\n", nil
 	case "shell":
 		var b bytes.Buffer
 		// todo: this should handle arrays and 1d tables
-		for k, v := range n.ToFlatMap() {
+		for k, v := range n.toFlatMap() {
 			k = strings.ReplaceAll(k, ".", "_")
 			// todo: meh on this replace value
 			k = strings.ReplaceAll(k, "-", "_")
@@ -247,4 +256,3 @@ func (n Node) View(kind string) (string, error) {
 // 	}
 // 	return result.String()
 // }
-

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ fi
 
 toml=$(cat <<EOF
 ref = '{{.b.localA}}'
-ref1 = '{{.a.dashed-ident}}'
+# ref1 = '{{.a.dashed-ident}}'
 ref2 = '{{.a.zero}}'
 negative-one = '{{sub .a.zero 1}}'
 
@@ -15,7 +15,7 @@ negative-one = '{{sub .a.zero 1}}'
 a = 'wow!!'
 a2 = 'ok {{.a}}'
 a3 = [ 'fancy', 'words' ]
-a4 = '{{.a3.0}}'
+# a4 = '{{.a3.0}}'
 dashed-ident = '{{.a}}'
 one = 1
 zero = '{{sub .one 1}}'
@@ -57,7 +57,8 @@ die() {
 
 if [ "$1" = "-d" ]; then
     # debug
-    timeout .1 ./gott -T "$toml" -v -o toml
+    # timeout .1 ./gott -T "$toml" -v -o toml
+    timeout 1 ./gott -T "$toml" -v -o toml
     exit $?
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ fi
 
 toml=$(cat <<EOF
 ref = '{{.b.localA}}'
-# ref1 = '{{.a.dashed-ident}}'
+ref1 = '{{.a.dashed-ident}}'
 ref2 = '{{.a.zero}}'
 negative-one = '{{sub .a.zero 1}}'
 
@@ -15,7 +15,7 @@ negative-one = '{{sub .a.zero 1}}'
 a = 'wow!!'
 a2 = 'ok {{.a}}'
 a3 = [ 'fancy', 'words' ]
-# a4 = '{{.a3.0}}'
+a4 = '{{.a3.0}}'
 dashed-ident = '{{.a}}'
 one = 1
 zero = '{{sub .one 1}}'
@@ -57,8 +57,8 @@ die() {
 
 if [ "$1" = "-d" ]; then
     # debug
-    # timeout .1 ./gott -T "$toml" -v -o toml
-    timeout 1 ./gott -T "$toml" -v -o toml
+    timeout .1 ./gott -T "$toml" -v -o toml
+    # timeout 1 ./gott -T "$toml" -v -o toml
     exit $?
 fi
 

--- a/transform.go
+++ b/transform.go
@@ -3,77 +3,83 @@ package main
 import (
 	"fmt"
 	"regexp"
-	"strconv"
-	"strings"
+	// "strings"
 )
 
 // The go template default selection mechanism kinda sucks
 // you can't used dashes or numbers, even if they are keys in a table
 // invalid: {{.wow.0}} {{.wow-ok}}
 // but we want that (mostly dashes). so we'll take every selection and turn it into an index function call.
-func identTransform(v string, c config, path []string) (string, error) {
-	identRe := regexp.MustCompile("({{)[^{}\\.]*((\\.[a-zA-Z0-9-]+)+)[^{}]*(}})")
-	// reference
-	// match: {{sub .a.some-test 1}}
-	// Match groups :
-	// 0	-	{{
-	// 1	-	.a.some-test
-	// 2	-	.some-test
-	// 3	-	}}
+// func identTransform(v string, c config, path []string) (string, error) {
+// 	identRe := regexp.MustCompile("({{)[^{}\\.]*((\\.[a-zA-Z0-9-]+)+)[^{}]*(}})")
+// 	// reference
+// 	// match: {{sub .a.some-test 1}}
+// 	// Match groups :
+// 	// 0	-	{{
+// 	// 1	-	.a.some-test
+// 	// 2	-	.some-test
+// 	// 3	-	}}
 
-	// have to be a little delicate -- tracking moving point of the edit as we replace larger
-	// strings at indexes
-	delta := 0
+// 	// have to be a little delicate -- tracking moving point of the edit as we replace larger
+// 	// strings at indexes
+// 	delta := 0
 
-	matches := identRe.FindAllStringSubmatchIndex(fmt.Sprintf("%v", v), -1)
-	// matches and submatches are identified by byte index pairs within the input string:
-	// result[2*n:2*n+1] identifies the indexes of the nth submatch. The pair for n==0 identifies the
-	// match of the entire expression
-	for _, groups := range matches {
-		toString := func(n int) string {
-			return v[delta+groups[2*n] : delta+groups[2*n+1]]
-		}
-		fullMatch := toString(0)
-		ident := toString(2)
-		start := groups[2*2] + delta
-		end := groups[2*2+1] + delta
-		length := end - start
+// 	matches := identRe.FindAllStringSubmatchIndex(fmt.Sprintf("%v", v), -1)
+// 	// matches and submatches are identified by byte index pairs within the input string:
+// 	// result[2*n:2*n+1] identifies the indexes of the nth submatch. The pair for n==0 identifies the
+// 	// match of the entire expression
+// 	for _, groups := range matches {
+// 		toString := func(n int) string {
+// 			return v[delta+groups[2*n] : delta+groups[2*n+1]]
+// 		}
+// 		fullMatch := toString(0)
+// 		ident := toString(2)
+// 		start := groups[2*2] + delta
+// 		end := groups[2*2+1] + delta
+// 		length := end - start
 
-		// vlog("fullmatch: %s", fullMatch)
+// 		// vlog("fullmatch: %s", fullMatch)
 
-		// you're always replacing at the ident location, it's just a question of adding the ()
-		addingBraces := strings.ReplaceAll(fullMatch, " ", "") != "{{"+ident+"}}"
+// 		// you're always replacing at the ident location, it's just a question of adding the ()
+// 		addingBraces := strings.ReplaceAll(fullMatch, " ", "") != "{{"+ident+"}}"
 
-		parts := strings.Split(ident[1:], ".")
-		new := "index . "
-		for _, p := range parts {
-			pi, err := strconv.Atoi(p)
-			if err == nil {
-				new = fmt.Sprintf("%s %d", new, pi)
-			} else {
-				new = fmt.Sprintf("%s \"%s\"", new, p)
-			}
-		}
+// 		parts := strings.Split(ident[1:], ".")
+// 		new := "index . "
+// 		for _, p := range parts {
+// 			pi, err := strconv.Atoi(p)
+// 			if err == nil {
+// 				new = fmt.Sprintf("%s %d", new, pi)
+// 			} else {
+// 				new = fmt.Sprintf("%s \"%s\"", new, p)
+// 			}
+// 		}
 
-		if addingBraces {
-			new = fmt.Sprintf("(%s)", new)
-		}
+// 		if addingBraces {
+// 			new = fmt.Sprintf("(%s)", new)
+// 		}
 
-		v = v[:start] + new + v[end:]
-		delta = delta + len(new) - length
+// 		v = v[:start] + new + v[end:]
+// 		delta = delta + len(new) - length
+// 	}
+
+// 	return v, nil
+// }
+
+
+
+func qualifyTransform(n *Node, path NodePath, rootNode Node) (interface{}, error) {
+	if fmt.Sprintf("%T", n.value) != "string" {
+		return n.value, nil
 	}
 
-	return v, nil
-}
+	v := n.value.(string)
 
-func qualifyTransform(v string, c config, path []string) (string, error) {
 	identRe := regexp.MustCompile("({{| )((\\.[a-zA-Z0-9-]+)+)")
 	matches := identRe.FindAllStringSubmatchIndex(fmt.Sprintf("%v", v), -1)
-	parent, _, _ := c.Dig(path[0 : len(path)-1])
+	parent := rootNode.mustFind(path[0 : len(path)-1]...)
 
 	if len(matches) > 0 {
-		name := strings.Join(path, ".")
-		vlog("\nqualifying .%s: %s", name, v)
+		vlog("\nqualifying .%s: %s", path.ToString(), v)
 	}
 
 	delta := 0
@@ -85,11 +91,11 @@ func qualifyTransform(v string, c config, path []string) (string, error) {
 		end := groups[2*2+1] + delta
 		length := end - start
 
-		matchPath := strings.Split(toString(2)[1:], ".")
+		matchPath := toPath(toString(2)[1:])
 		matchKey := matchPath[0]
 
 		vlog("parent: %v", parent)
-		vlog("looking at: .%s", strings.Join(path, "."))
+		vlog("looking at: .%s", path.ToString())
 		vlog("matchKey, matchPath: %s, %v", matchKey, matchPath)
 
 		disqualify := func(cond bool, message string) bool {
@@ -99,16 +105,20 @@ func qualifyTransform(v string, c config, path []string) (string, error) {
 			return cond
 		}
 
-		_, in_parent := parent[matchKey]
-		_, digIsMap, digErr := c.Dig(matchPath)
+		_, err := parent.find(matchKey)
+		in_parent := err != nil
+
+		u, digErr := rootNode.find(matchPath...)
+		isValue := len(u.children) == 0
 
 		if disqualify(matchKey == path[len(path)-1], "self") ||
 			disqualify(!in_parent, "not present in parent") ||
-			disqualify(digErr == nil && !digIsMap, "matchPath exists in map, and is a value") {
+			disqualify(digErr == nil && isValue, "matchPath exists in map, and is a value") {
 			continue
 		}
 
-		new := "." + strings.Join(append(path[0:len(path)-1], matchPath...), ".")
+		parts := append(path[0:len(path)-1], matchPath...)
+		new := "." + parts.ToString()
 		v = v[:start] + new + v[end:]
 		delta = delta + len(new) - length
 	}

--- a/transform.go
+++ b/transform.go
@@ -71,6 +71,7 @@ func qualifyTransform(n *Node, path NodePath, rootNode Node) (interface{}, error
 	if fmt.Sprintf("%T", n.value) != "string" {
 		return n.value, nil
 	}
+	path = path[1:]
 
 	v := n.value.(string)
 
@@ -108,16 +109,18 @@ func qualifyTransform(n *Node, path NodePath, rootNode Node) (interface{}, error
 		_, err := parent.find(matchKey)
 		in_parent := err != nil
 
-		u, digErr := rootNode.find(matchPath...)
-		isValue := len(u.children) == 0
+		_, digErr := rootNode.find(matchPath...)
+		// isValue := len(u.children) == 0
 
+			// disqualify(digErr == nil && isValue, "matchPath exists in map, and is a value") {
 		if disqualify(matchKey == path[len(path)-1], "self") ||
 			disqualify(!in_parent, "not present in parent") ||
-			disqualify(digErr == nil && isValue, "matchPath exists in map, and is a value") {
+			disqualify(digErr == nil, "matchPath exists in map") {
 			continue
 		}
 
-		parts := append(path[0:len(path)-1], matchPath...)
+		parts := append(path[0:len(path)-2], matchPath...)
+		// new := parts.ToIndexCall()
 		new := "." + parts.ToString()
 		v = v[:start] + new + v[end:]
 		delta = delta + len(new) - length

--- a/transform.go
+++ b/transform.go
@@ -11,7 +11,7 @@ import (
 // invalid: {{.wow.0}} {{.wow-ok}}
 // but we want that (mostly dashes). so we'll take every selection and turn it into an index function call.
 func identTransform(v string) (string, error) {
-	identRe := regexp.MustCompile(`({{)[^{}\.]*((\.[a-zA-Z0-9-]+)+)[^{}]*(}})`)
+	identRe := regexp.MustCompile(`({{)[^{}\.]*((\.[a-zA-Z0-9-_]+)+)[^{}]*(}})`)
 	// reference
 	// match: {{sub .a.some-test 1}}
 	// Match groups :

--- a/util.go
+++ b/util.go
@@ -107,13 +107,3 @@ func parseToml(tomlFiles, tomlText []string) map[string]interface{} {
 	return result
 }
 
-// func makeTree(source interface{}, root Node, interface ) {
-// 	for _, v := range path {
-// 		switch v := v.(type) {
-// 		case string:
-// 			result = result + v + "."
-// 		case int:
-// 			result = result + fmt.Sprintf("%d", v) + "."
-// 		}
-// 	}
-// }

--- a/util.go
+++ b/util.go
@@ -18,28 +18,6 @@ func vlog(format string, args ...interface{}) {
 	}
 }
 
-func flattenMap(results map[string]string, m map[string]interface{}, namespace string) {
-	if namespace != "" {
-		namespace = namespace + "."
-	}
-
-	for key, value := range m {
-		nested, is_map := value.(map[string]interface{})
-		_, is_array := value.([]interface{})
-		if is_map {
-			flattenMap(results, nested, namespace+key)
-		} else if is_array {
-			// do nothing (string array indexes sounds gross)
-			// for index, _ := range arrayVal {
-			// 	index_string := fmt.Sprintf("[%i]", index)
-			// 	flattenMap(nested, namespace + key + index_string, results)
-			// }
-		} else {
-			results[namespace+key] = fmt.Sprintf("%v", value)
-		}
-	}
-}
-
 func makeTemplate() *template.Template {
 	funcMap := (sprig.TxtFuncMap())
 	funcMap["shpipe"] = func(command, value string) string {
@@ -83,7 +61,8 @@ func makeTemplate() *template.Template {
 	return template.New("").Option("missingkey=zero").Funcs(funcMap)
 }
 
-func parseToml(tomlFiles, tomlText []string) config {
+
+func parseToml(tomlFiles, tomlText []string) map[string]interface{} {
 	result := map[string]interface{}{}
 
 	for _, file := range tomlFiles {
@@ -107,4 +86,15 @@ func parseToml(tomlFiles, tomlText []string) config {
 	}
 
 	return result
+}
+
+func makeTree(source interface{}, root Node, interface ) {
+	for _, v := range path {
+		switch v := v.(type) {
+		case string:
+			result = result + v + "."
+		case int:
+			result = result + fmt.Sprintf("%d", v) + "."
+		}
+	}
 }

--- a/util.go
+++ b/util.go
@@ -13,16 +13,16 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-func mapToNode(n *Node, value interface{}, path NodePath, action func(NodePath)) {
+func mapToNode(n *Node, value interface{}, path NodePath) {
 	nested, is_map := value.(map[string]interface{})
 	arrayVal, is_array := value.([]interface{})
 	if is_map {
 		for key, _ := range nested {
-			mapToNode(n, nested[key], append(path, key), action)
+			mapToNode(n, nested[key], append(path, key))
 		}
 	} else if is_array {
 		for index, _ := range arrayVal {
-			mapToNode(n, arrayVal[index], append(path, index), action)
+			mapToNode(n, arrayVal[index], append(path, index))
 		}
 	} else {
 		// results[namespace+key] = fmt.Sprintf("%v", value)


### PR DESCRIPTION
This introduces a node type for building the nested table/array representation. Referencing is now complected - you can't reference number-strings, because they are coerced into array indexes. The main motivation is to get away from using map[string]interface{} everywhere, instead attempting our own wrapping around it (one top level string->NodePath function was still needed -- you can't define functions on primitive types)

niceties missing:
- a changeStringLeaves() call
- Node should probably be it's own package, NewNode() -> New
- better path -> index call transforming is still needed (#2)
- logging!!! tie the global log thing to tests